### PR TITLE
ar71xx: Update 82_patch_ath10k to fix MAC issue

### DIFF
--- a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -18,6 +18,9 @@ case "$board" in
 	archer-c60-v2)
 		echo $(macaddr_add $(mtd_get_mac_binary mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
 		;;
+	tew-823dru)
+	        echo $(macaddr_add $(strings $(find_mtd_part mac) | head -n1 ) $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
+		;;
 	*)
 		;;
 esac

--- a/target/linux/ar71xx/base-files/lib/preinit/82_patch_ath10k
+++ b/target/linux/ar71xx/base-files/lib/preinit/82_patch_ath10k
@@ -29,17 +29,6 @@ do_patch_ath10k_firmware() {
 		macaddr_2bin $mac | dd of=/tmp/ath10k-firmware.bin \
 			conv=notrunc bs=1 seek=$mac_offset count=$mac_length
 		;;
-	tew-823dru)
-		local mac
-		local part
-		part=$(find_mtd_part mac)
-
-		# second mac address is wan mac. Use this for wlan
-		mac=$(strings "$part" | head -n2 | tail -n1)
-		cp $firmware_file /tmp/ath10k-firmware.bin
-		macaddr_2bin $mac | dd of=/tmp/ath10k-firmware.bin \
-			conv=notrunc bs=1 seek=$mac_offset count=$mac_length
-		;;
 	esac
 
 	[ -f /tmp/ath10k-firmware.bin ] || return
@@ -50,8 +39,7 @@ do_patch_ath10k_firmware() {
 
 check_patch_ath10k_firmware() {
 	case $(board_name) in
-	dgl-5500-a1|\
-	tew-823dru)
+	dgl-5500-a1)
 		do_patch_ath10k_firmware
 		;;
 	esac

--- a/target/linux/ar71xx/base-files/lib/preinit/82_patch_ath10k
+++ b/target/linux/ar71xx/base-files/lib/preinit/82_patch_ath10k
@@ -9,7 +9,7 @@ do_patch_ath10k_firmware() {
 	# bail out if firmware does not exist
 	[ -f "$firmware_file" ] || return
 
-	local mac_offset=276
+	local mac_offset=280
 	local mac_length=6
 	local default_mac="00:03:07:12:34:56"
 	local current_mac="$(hexdump -v -n $mac_length -s $mac_offset -e '5/1 "%02x:" 1/1 "%02x"' $firmware_file  2>/dev/null)"
@@ -21,11 +21,21 @@ do_patch_ath10k_firmware() {
 	# we have to patch the default mac in the firmware because we cannot change
 	# the otp.
 	case $(board_name) in
-	dgl-5500-a1|\
-	tew-823dru)
+	dgl-5500-a1)
 		local mac
 		mac=$(mtd_get_mac_ascii nvram wlan1_mac)
 
+		cp $firmware_file /tmp/ath10k-firmware.bin
+		macaddr_2bin $mac | dd of=/tmp/ath10k-firmware.bin \
+			conv=notrunc bs=1 seek=$mac_offset count=$mac_length
+		;;
+	tew-823dru)
+		local mac
+		local part
+		part=$(find_mtd_part mac)
+
+		# second mac address is wan mac. Use this for wlan
+		mac=$(strings "$part" | head -n2 | tail -n1)
 		cp $firmware_file /tmp/ath10k-firmware.bin
 		macaddr_2bin $mac | dd of=/tmp/ath10k-firmware.bin \
 			conv=notrunc bs=1 seek=$mac_offset count=$mac_length


### PR DESCRIPTION
Fixed the current patch to look for the MAC address in the correct location in the firmware file. Also for the TEW-823DRU the nvram partition does not contain a wlan1_mac key so we set the wlan mac address to the same address as the WAN mac address to ensure that each adapter has a unique address.

